### PR TITLE
Fix EZP-21814: Configure CI to run jshint and csslint on PR

### DIFF
--- a/bin/postComment.php
+++ b/bin/postComment.php
@@ -12,7 +12,10 @@ curl_setopt( $ch, CURLOPT_HEADER, true );
 curl_setopt( $ch, CURLOPT_POST, true );
 curl_setopt( $ch, CURLOPT_USERAGENT, "ezrobot PR CodeSniffer" );
 curl_setopt( $ch, CURLOPT_HTTPHEADER, array( 'Content-Type: application/json' ) );
-curl_setopt( $ch, CURLOPT_POSTFIELDS, json_encode( array( "body" => "This Pull Request does not respect our [Coding Standards](https://github.com/ezsystems/ezcs), please, see the report below:\n\n```\n" . file_get_contents( $argv[2] ) . "\n```" ) ) );
+curl_setopt(
+    $ch, CURLOPT_POSTFIELDS,
+    json_encode( array( "body" => file_get_contents( $argv[2] ) ) )
+);
 
 curl_exec( $ch );
 curl_close( $ch );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21814
# Description

Changes the script used to comment on pull request on ezpublish-kernel and ezpublish-community, to also support jshint, csslint and yuidoc checkings.
## Comment example for PHP

This Pull Request does not respect our [PHP Coding Standards](https://github.com/ezsystems/ezcs/tree/master/php), please, see the report below:

```
FILE: /home/dp/dev/ezpublish-kernel/eZ/Publish/Core/Repository/Repository.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 26 | ERROR | Opening brace of a class must be on the line after the definition
--------------------------------------------------------------------------------
```
## Comment example for JavaScript (jshint)

jshint with [our configuration](https://github.com/ezsystems/ezcs/tree/master/js) reports the following issues:

```
src/services/ContentService.js: line 45, col 50, Missing semicolon. (W033)
src/services/ContentService.js: line 1, col 1, 'define' is not defined. (W117)

2 errors
```

```
src/CAPI.js: line 1, col 1, 'define' is not defined. (W117)

1 error
```
## Comment example for CSS (csslint)

csslint with [our configuration](https://github.com/ezsystems/ezcs/tree/master/css) reports the following errors:

```
Resources/public/css/errorview.css: line 1, col 1, Error - Rule is empty.
Resources/public/css/errorview.css: line 3, col 8, Error - Unknown property 'bord'.
Resources/public/css/layout.css: line 35, col 5, Error - Missing standard property 'transform' to go along with '-moz-transform'.
Resources/public/css/layout.css: line 38, col 5, Error - Missing standard property 'transform' to go along with '-moz-transform'.
Resources/public/css/layout.css: line 43, col 5, Error - Missing standard property 'transform' to go along with '-webkit-transform'.
Resources/public/css/layout.css: line 46, col 5, Error - Missing standard property 'transform' to go along with '-webkit-transform'.
Resources/public/css/layout.css: line 51, col 5, Error - Missing standard property 'transform' to go along with '-o-transform'.
Resources/public/css/layout.css: line 54, col 5, Error - Missing standard property 'transform' to go along with '-o-transform'.
Resources/public/css/layout.css: line 57, col 1, Error - Unknown @ rule: @-ms-keyframes.
Resources/public/css/theme.css: line 54, col 1, Error - Outlines should only be modified using :focus.
```
## Comment example for yuidoc lint

yuidoc reports the following documentation warnings:

```
YUIDoc found 2 lint errors in your docs
#1 replacing incorrect tag: returns with return  src/connections/MicrosoftXmlHttpRequestConnection.js:69

#2 replacing incorrect tag: returns with return  src/connections/XmlHttpRequestConnection.js:68

```
# Tasks
- [x] handle credentials with Jenkins' global passwords
- [x] add support for jshint
- [x] add support for csslint
- [x] add yuidoc lint for JS files
- [x] improve ezrobot's comments
- [x] setup the new script versions on CI
