### PR TITLE
Added a script to set the status of a commit on github

### DIFF
--- a/bin/setCommitStatus.php
+++ b/bin/setCommitStatus.php
@@ -1,0 +1,33 @@
+#!/usr/bin/php
+<?php
+
+$login = 'ezrobot';
+
+$repo = $argv[1];
+$sha1 = $argv[2];
+$state = $argv[3];
+$url = $argv[4];
+$description = isset( $argv[5] ) ? $argv[5] : "";
+
+$ch = curl_init( "https://api.github.com/repos/ezsystems/$repo/statuses/$sha1" );
+
+curl_setopt( $ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC );
+curl_setopt( $ch, CURLOPT_USERPWD, $login . ':' . $_ENV[$login] );
+curl_setopt( $ch, CURLOPT_SSLVERSION, 3 );
+curl_setopt( $ch, CURLOPT_HEADER, true );
+curl_setopt( $ch, CURLOPT_POST, true );
+curl_setopt( $ch, CURLOPT_USERAGENT, "ezrobot" );
+curl_setopt( $ch, CURLOPT_HTTPHEADER, array( 'Content-Type: application/json' ) );
+curl_setopt(
+    $ch, CURLOPT_POSTFIELDS,
+    json_encode(
+        array(
+            'state' => $state,
+            'target_url' => $url,
+            'description' => $description
+        )
+    )
+);
+
+curl_exec( $ch );
+curl_close( $ch );


### PR DESCRIPTION
Related to the JIRA issue [Setup CI for the EditorialBundle](https://jira.ez.no/browse/EZP-21277)
# Description

This PR adds a script to set the status of commit with the Github REST API to used on private repo.
# Test

manual tests on this PR
