### PR TITLE
Fix: Support trait declaration in 5.4.0+

### DIFF
--- a/php/ezcs/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/php/ezcs/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -63,6 +63,12 @@ class ezcs_Sniffs_NamingConventions_UpperCaseConstantNameSniff implements PHP_Co
                     // This is just a declaration; no constants here.
                     return;
             }
+            if ( version_compare( PHP_VERSION, '5.4.0') >= 0 ) {
+                switch ($tokens[$functionKeyword]['code']) {
+                    case T_TRAIT:
+                        return;
+                }
+            }
 
             if ($tokens[$functionKeyword]['code'] === T_CONST) {
                 // This is a class constant.


### PR DESCRIPTION
ezcs incorrectly identifies Traits as class constants.

For example, given the following code:

``` php
trait SomeTrait
{

}
```

The following error will be output:
 `15 | ERROR | Constants must be uppercase; expected SOMETRAIT but found SomeTrait`

This fixes it by adding a specific check when using php 5.4.0+, as per http://php.net/manual/en/tokens.php
